### PR TITLE
Update main.m

### DIFF
--- a/main.m
+++ b/main.m
@@ -18,7 +18,7 @@ end
 config = loadjson('config.json')
 
 disp('loading dt6.mat')
-dt6 = load(fullfile(config.dtiinit, '/dti/dt6.mat'))
+dt6 = loadjson(fullfile(config.dtiinit, 'dt6.json'))
 aligned_dwi = fullfile(config.dtiinit, dt6.files.alignedDwRaw)
 
 [ fe, out ] = life(config, aligned_dwi);


### PR DESCRIPTION
Changing the dt6 input from the dt6.m file to the dt6.json file will allow the output from epi t1 registration (dt6.mat (which doesn't include the subfield "files" due to the script used to create the dt6), and a dt6.json (which does contain the "files" subfield"). 

Since the dt6 variable is just being used for pointing to the alignedDwRaw file.  I've checked, and dtiinit and the epi t1 registration app both have the alignedDwRaw file set properly in the dt6.json alignedDwRaw subfield.